### PR TITLE
chore: update livewire/livewire to ^3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8",
-        "livewire/livewire": "^3.4",
+        "livewire/livewire": "^3.5",
         "livewire/volt": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Actualiza la dependencia de livewire/livewire a la versión ^3.5 en composer.json para mantener el proyecto actualizado con la última versión estable de Livewire.